### PR TITLE
fix: RocketMQ set the consumer's tags, it will still receive all the messages of the topic #24

### DIFF
--- a/plugins/cloudopt-next-rocketmq/src/main/kotlin/net/cloudopt/next/rocketmq/RocketMQPlugin.kt
+++ b/plugins/cloudopt-next-rocketmq/src/main/kotlin/net/cloudopt/next/rocketmq/RocketMQPlugin.kt
@@ -192,11 +192,13 @@ class RocketMQPlugin : Plugin {
                 RocketMQManager.consumer.registerMessageListener(MessageListenerOrderly { msgs, context ->
                     msgs.forEach { msg ->
                         RocketMQManager.listenerList[msg.topic]?.forEach { clazz ->
-                            val instance = clazz.createInstance() as RocketMQListener
-                            instance.listener(msg)
+                            val annotation = clazz.findAnnotation<AutoRocketMQ>()
+                            if(annotation?.subExpression == "*" || annotation?.subExpression?.split("||")?.contains(msg.tags) == true) {
+                                val instance = clazz.createInstance() as RocketMQListener
+                                instance.listener(msg)
+                            }
                         }
                     }
-
                     ConsumeOrderlyStatus.SUCCESS
                 })
             } else {
@@ -206,11 +208,13 @@ class RocketMQPlugin : Plugin {
                 RocketMQManager.consumer.registerMessageListener(MessageListenerConcurrently { msgs, context ->
                     msgs.forEach { msg ->
                         RocketMQManager.listenerList[msg.topic]?.forEach { clazz ->
-                            val instance = clazz.createInstance() as RocketMQListener
-                            instance.listener(msg)
+                            val annotation = clazz.findAnnotation<AutoRocketMQ>()
+                            if(annotation?.subExpression == "*" || annotation?.subExpression?.split("||")?.contains(msg.tags) == true) {
+                                val instance = clazz.createInstance() as RocketMQListener
+                                instance.listener(msg)
+                            }
                         }
                     }
-
                     ConsumeConcurrentlyStatus.CONSUME_SUCCESS
                 })
             }

--- a/plugins/cloudopt-next-rocketmq/src/test/kotlin/net/cloudopt/next/rocketmq/test/IndexController.kt
+++ b/plugins/cloudopt-next-rocketmq/src/test/kotlin/net/cloudopt/next/rocketmq/test/IndexController.kt
@@ -43,7 +43,6 @@ class IndexController : Resource() {
             "TagA" /* Tag */,
             "Hello RocketMQ".toByteArray(charset = Charsets.UTF_8)
         )
-        val sendResult: SendResult = RocketMQManager.producer.send(msg)
         RocketMQManager.producer.send(msg)
         renderJson("Send Event!")
     }


### PR DESCRIPTION
In RocketMQ, every message only have one Tag ,but consumer can listener mang tags , like ("TOPIC", "TAGA || TAGB || TAGC")
doc http://rocketmq.apache.org/docs/filter-by-sql92-example/