### PR TITLE
fix (RedisManager)：Function “sync” returns not null

### DIFF
--- a/plugins/cloudopt-next-redis/src/main/kotlin/net/cloudopt/next/redis/RedisManager.kt
+++ b/plugins/cloudopt-next-redis/src/main/kotlin/net/cloudopt/next/redis/RedisManager.kt
@@ -83,7 +83,7 @@ object RedisManager {
      * @param name Multiple data sources are supported from version 3.1.0.0,
      * please declare the data source used.
      */
-    fun sync(name: String = "default"): RedisCommands<String, String>? {
+    fun sync(name: String = "default"): RedisCommands<String, String> {
         return connectionMap[name]!!.sync()
     }
 


### PR DESCRIPTION
- Making the function `sync` in RedisManager return not null allows users to upgrade from `3.0.3.0-RELEASE` to `3.1.0.0-SNAPSHOT` versions without having to use `RedisManager.sync()?.` calls